### PR TITLE
Added get_tags() support for subscriptions.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AzureRMR
 Title: Interface to 'Azure Resource Manager'
-Version: 2.4.3-bn
+Version: 2.4.4
 Authors@R: c(
     person("Hong", "Ooi", , "hongooi73@gmail.com", role = c("aut", "cre")),
     person("Microsoft", role="cph")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AzureRMR
 Title: Interface to 'Azure Resource Manager'
-Version: 2.4.3
+Version: 2.4.3-bn
 Authors@R: c(
     person("Hong", "Ooi", , "hongooi73@gmail.com", role = c("aut", "cre")),
     person("Microsoft", role="cph")

--- a/R/az_subscription.R
+++ b/R/az_subscription.R
@@ -86,6 +86,7 @@ public=list(
     state=NULL,
     policies=NULL,
     authorization_source=NULL,
+    tags=NULL,
     token=NULL,
 
     initialize=function(token, id=NULL, parms=list())

--- a/R/az_subscription.R
+++ b/R/az_subscription.R
@@ -26,6 +26,7 @@
 #' - `list_role_assignments()`: Lists role assignments.
 #' - `get_role_definition(id)`: Retrieves an existing role definition.
 #' - `list_role_definitions()` Lists role definitions.
+#' - `get_tags()` Get the tags on this subscription.
 #'
 #' @section Details:
 #' Generally, the easiest way to create a subscription object is via the `get_subscription` or `list_subscriptions` methods of the [az_rm] class. To create a subscription object in isolation, call the `new()` method and supply an Oauth 2.0 token of class [AzureToken], along with the ID of the subscription.
@@ -102,6 +103,7 @@ public=list(
         self$state <- parms$state
         self$policies <- parms$subscriptionPolicies
         self$authorization_source <- parms$authorizationSource
+        self$tags <- parms$tags
         NULL
     },
 
@@ -154,6 +156,13 @@ public=list(
             }
             else sapply(apis, select_version)
         }
+    },
+    
+    get_tags=function()
+    {
+        if(is.null(self$tags))
+            named_list()
+        else self$tags
     },
 
     get_resource_group=function(name)


### PR DESCRIPTION
Just a very simple change, I wanted to get tags defined at the subscription level. Works like a charm in my test environment, it gets subscription level tags just as it would resource group or resource level tags.