### PR TITLE
fix lapply argument in 'list_azure_logins'

### DIFF
--- a/R/az_login.R
+++ b/R/az_login.R
@@ -196,7 +196,7 @@ list_azure_logins <- function()
     logins <- sapply(arm_logins, function(tenant)
     {
         sapply(tenant,
-            function(hash) az_rm$new(token=load_azure_token(file)),
+            function(hash) az_rm$new(token=load_azure_token(hash)),
             simplify=FALSE)
     }, simplify=FALSE)
 


### PR DESCRIPTION
At https://github.com/Azure/AzureRMR/blame/da4751a30df58360db054abd5e4584d5bdbbdc57/R/az_login.R#L199
the argument to `load_azure_token(hash)` should be the lapply function argument `hash` and not `file`

```r
function(hash) az_rm$new(token=load_azure_token(hash))
```

closes #30 
